### PR TITLE
SLING-3049 - Make Logback Stacktrace Packaging data support OSGi aware

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -326,6 +326,18 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>biz.aQute.bnd</groupId>
+      <artifactId>bndlib</artifactId>
+      <version>2.4.0</version>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>org.osgi</groupId>
+          <artifactId>org.osgi.core</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
       <groupId>javax.inject</groupId>
       <artifactId>javax.inject</artifactId>
       <version>1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
     <slf4j.version>1.7.21</slf4j.version>
     <logback.version>1.2.3</logback.version>
     <pax-exam.version>3.5.0</pax-exam.version>
+    <sling.java.version>8</sling.java.version>
 
     <bundle.build.dir>
       ${basedir}/target
@@ -390,6 +391,12 @@
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-integration</artifactId>
       <version>1.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>2.11.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/org/apache/sling/commons/log/logback/internal/LogConfig.java
+++ b/src/main/java/org/apache/sling/commons/log/logback/internal/LogConfig.java
@@ -27,6 +27,8 @@ import java.util.regex.Pattern;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.PatternLayout;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.pattern.PostCompileProcessor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,6 +56,8 @@ public class LogConfig {
     private final boolean isAdditiv;
 
     private final boolean resetToDefault;
+
+    private PostCompileProcessor<ILoggingEvent> postProcessor;
 
     LogConfig(LogWriterProvider logWriterProvider, final String pattern, Set<String> categories, Level logLevel,
               String logWriterName, final boolean isAdditiv, String configPid, LoggerContext loggerContext, boolean resetToDefault) {
@@ -145,6 +149,11 @@ public class LogConfig {
         pl.setPattern(logBackPattern);
         pl.setOutputPatternAsHeader(false);
         pl.setContext(loggerContext);
+
+        if (postProcessor != null) {
+            pl.setPostCompileProcessor(postProcessor);
+        }
+
         pl.start();
         return pl;
     }
@@ -153,6 +162,10 @@ public class LogConfig {
     public String toString() {
         return "LogConfig{" + "configPid='" + configPid + '\'' + ", categories=" + categories + ", logLevel="
             + logLevel + ", logWriterName='" + logWriterName + '\'' + '}';
+    }
+
+    public void setPostProcessor(PostCompileProcessor<ILoggingEvent> postProcessor) {
+        this.postProcessor = postProcessor;
     }
 
     public interface LogWriterProvider {

--- a/src/main/java/org/apache/sling/commons/log/logback/internal/LogConfigManager.java
+++ b/src/main/java/org/apache/sling/commons/log/logback/internal/LogConfigManager.java
@@ -42,6 +42,7 @@ import ch.qos.logback.core.joran.action.ActionConst;
 import ch.qos.logback.core.util.ContextUtil;
 import org.apache.sling.commons.log.logback.internal.config.ConfigAdminSupport;
 import org.apache.sling.commons.log.logback.internal.config.ConfigurationException;
+import org.apache.sling.commons.log.logback.internal.stacktrace.OSGiAwareExceptionHandling;
 import org.apache.sling.commons.log.logback.internal.util.LoggerSpecificEncoder;
 import org.apache.sling.commons.log.logback.internal.util.Util;
 import org.osgi.framework.BundleContext;
@@ -564,6 +565,9 @@ public class LogConfigManager implements LogbackResetListener, LogConfig.LogWrit
             // create or modify existing configuration object
             final LogConfig newConfig = new LogConfig(this, pattern, categories, logLevel, fileName, additiv,
                     pid, loggerContext, resetToDefault);
+            if (isPackagingDataEnabled()) {
+                newConfig.setPostProcessor(new OSGiAwareExceptionHandling(logbackManager.getPackageInfoCollector()));
+            }
             LogConfig oldConfig = configByPid.get(pid);
             if (oldConfig != null) {
                 configByCategory.keySet().removeAll(oldConfig.getCategories());

--- a/src/main/java/org/apache/sling/commons/log/logback/internal/SlingLogPanel.java
+++ b/src/main/java/org/apache/sling/commons/log/logback/internal/SlingLogPanel.java
@@ -176,8 +176,8 @@ public class SlingLogPanel implements LogPanel {
 
     private void appendLoggerStatus(PrintWriter pw, LoggerStateContext ctx) {
         pw.printf(
-                "<p class='statline'>Log Service Stats: %d categories, %d appender, %d Dynamic appenders</p>%n",
-                ctx.getNumberOfLoggers(), ctx.getNumOfAppenders(), ctx.getNumOfDynamicAppenders());
+                "<p class='statline'>Log Service Stats: %d categories, %d appender, %d Dynamic appenders, %d Packages</p>%n",
+                ctx.getNumberOfLoggers(), ctx.getNumOfAppenders(), ctx.getNumOfDynamicAppenders(), ctx.packageInfoCollector.size());
     }
 
     private void appendOsgiConfiguredLoggerData(final PrintWriter pw, final String consoleAppRoot) {

--- a/src/main/java/org/apache/sling/commons/log/logback/internal/stacktrace/OSGiAwareExceptionHandling.java
+++ b/src/main/java/org/apache/sling/commons/log/logback/internal/stacktrace/OSGiAwareExceptionHandling.java
@@ -51,9 +51,9 @@ public class OSGiAwareExceptionHandling extends EnsureExceptionHandling {
         @Override
         protected void extraData(StringBuilder builder, StackTraceElementProxy step) {
             if (step != null) {
-                String version = collector.getVersion(step.getStackTraceElement().getClassName());
-                if (version != null) {
-                    builder.append(" [").append(version).append(']');
+                String bundleInfo = collector.getBundleInfo(step.getStackTraceElement().getClassName());
+                if (bundleInfo != null) {
+                    builder.append(" [").append(bundleInfo).append(']');
                 }
             }
         }

--- a/src/main/java/org/apache/sling/commons/log/logback/internal/stacktrace/OSGiAwareExceptionHandling.java
+++ b/src/main/java/org/apache/sling/commons/log/logback/internal/stacktrace/OSGiAwareExceptionHandling.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sling.commons.log.logback.internal.stacktrace;
+
+import ch.qos.logback.classic.pattern.EnsureExceptionHandling;
+import ch.qos.logback.classic.pattern.ExtendedThrowableProxyConverter;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.StackTraceElementProxy;
+import ch.qos.logback.core.Context;
+import ch.qos.logback.core.pattern.Converter;
+import ch.qos.logback.core.pattern.ConverterUtil;
+
+public class OSGiAwareExceptionHandling extends EnsureExceptionHandling {
+    private final PackageInfoCollector collector;
+
+    public OSGiAwareExceptionHandling(PackageInfoCollector collector) {
+        this.collector = collector;
+    }
+
+    @Override
+    public void process(Context context, Converter<ILoggingEvent> head) {
+        if (head == null) {
+            // this should never happen
+            throw new IllegalArgumentException("cannot process empty chain");
+        }
+        if (!chainHandlesThrowable(head)) {
+            Converter<ILoggingEvent> tail = ConverterUtil.findTail(head);
+            Converter<ILoggingEvent> exConverter = new OSGiAwareConverter();
+            tail.setNext(exConverter);
+        }
+    }
+
+    private class OSGiAwareConverter extends ExtendedThrowableProxyConverter {
+        @Override
+        protected void extraData(StringBuilder builder, StackTraceElementProxy step) {
+            if (step != null) {
+                String version = collector.getVersion(step.getStackTraceElement().getClassName());
+                if (version != null) {
+                    builder.append(" [").append(version).append(']');
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/org/apache/sling/commons/log/logback/internal/stacktrace/PackageInfoCollector.java
+++ b/src/main/java/org/apache/sling/commons/log/logback/internal/stacktrace/PackageInfoCollector.java
@@ -26,7 +26,7 @@ import org.osgi.framework.hooks.weaving.WeavingHook;
 import org.osgi.framework.hooks.weaving.WovenClass;
 
 public class PackageInfoCollector implements WeavingHook{
-    private final Map<String, String> pkgVersionMapping = new ConcurrentHashMap<>();
+    private final Map<String, String> pkgInfoMapping = new ConcurrentHashMap<>();
 
     @Override
     public void weave(WovenClass wovenClass) {
@@ -34,19 +34,23 @@ public class PackageInfoCollector implements WeavingHook{
     }
 
     public int size() {
-        return pkgVersionMapping.size();
+        return pkgInfoMapping.size();
     }
 
     void add(Bundle bundle, String className) {
-        pkgVersionMapping.put(getPackageName(className), bundle.getVersion().toString());
+        pkgInfoMapping.put(getPackageName(className), getInfo(bundle));
     }
 
-    String getVersion(String className) {
+    String getBundleInfo(String className) {
         if (className == null) {
             return null;
         }
         String packageName = getPackageName(className);
-        return pkgVersionMapping.get(packageName);
+        return pkgInfoMapping.get(packageName);
+    }
+
+    static String getInfo(Bundle bundle) {
+        return bundle.getSymbolicName() + ":" + bundle.getVersion();
     }
 
     static String getPackageName(String className) {

--- a/src/main/java/org/apache/sling/commons/log/logback/internal/stacktrace/PackageInfoCollector.java
+++ b/src/main/java/org/apache/sling/commons/log/logback/internal/stacktrace/PackageInfoCollector.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.sling.commons.log.logback.internal.stacktrace;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.osgi.framework.Bundle;
+import org.osgi.framework.hooks.weaving.WeavingHook;
+import org.osgi.framework.hooks.weaving.WovenClass;
+
+public class PackageInfoCollector implements WeavingHook{
+    private final Map<String, String> pkgVersionMapping = new ConcurrentHashMap<>();
+
+    @Override
+    public void weave(WovenClass wovenClass) {
+        add(wovenClass.getBundleWiring().getBundle(), wovenClass.getClassName());
+    }
+
+    public int size() {
+        return pkgVersionMapping.size();
+    }
+
+    void add(Bundle bundle, String className) {
+        pkgVersionMapping.put(getPackageName(className), bundle.getVersion().toString());
+    }
+
+    String getVersion(String className) {
+        if (className == null) {
+            return null;
+        }
+        String packageName = getPackageName(className);
+        return pkgVersionMapping.get(packageName);
+    }
+
+    static String getPackageName(String className) {
+        int lastIndexOfDot = className.lastIndexOf('.');
+        String result = "";
+        if (lastIndexOfDot > 0){
+            result = className.substring(0, lastIndexOfDot);
+        }
+        return result;
+    }
+}

--- a/src/test/java/org/apache/sling/commons/log/logback/integration/ITConfigAdminSupport.java
+++ b/src/test/java/org/apache/sling/commons/log/logback/integration/ITConfigAdminSupport.java
@@ -172,7 +172,7 @@ public class ITConfigAdminSupport extends LogTestBase {
         // Set log level to debug for Root logger
         Configuration config = ca.getConfiguration(PID, null);
         Dictionary<String, Object> p = new Hashtable<String, Object>();
-        p.put(LOG_PACKAGING_DATA, Boolean.FALSE);
+        p.put(LOG_PACKAGING_DATA, Boolean.TRUE);
         p.put(LOG_LEVEL, "INFO");
         config.update(p);
 

--- a/src/test/java/org/apache/sling/commons/log/logback/integration/ITPackagingData.java
+++ b/src/test/java/org/apache/sling/commons/log/logback/integration/ITPackagingData.java
@@ -1,0 +1,191 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sling.commons.log.logback.integration;
+
+import java.io.File;
+import java.io.InputStream;
+import java.util.Dictionary;
+import java.util.Hashtable;
+import java.util.List;
+
+import javax.inject.Inject;
+
+import ch.qos.logback.classic.LoggerContext;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.FilenameUtils;
+import org.apache.sling.commons.log.logback.integration.bundle.PackageDataActivator;
+import org.apache.sling.commons.log.logback.internal.LogbackManager;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.ops4j.pax.exam.Option;
+import org.ops4j.pax.exam.junit.PaxExam;
+import org.ops4j.pax.exam.spi.reactors.ExamReactorStrategy;
+import org.ops4j.pax.exam.spi.reactors.PerMethod;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.Constants;
+import org.osgi.framework.Filter;
+import org.osgi.framework.FrameworkUtil;
+import org.osgi.framework.InvalidSyntaxException;
+import org.osgi.framework.hooks.weaving.WeavingHook;
+import org.osgi.service.cm.Configuration;
+import org.osgi.service.cm.ConfigurationAdmin;
+import org.osgi.util.tracker.ServiceTracker;
+import org.slf4j.LoggerFactory;
+
+import static org.apache.sling.commons.log.logback.integration.ITConfigAdminSupport.PID;
+import static org.apache.sling.commons.log.logback.internal.LogConfigManager.FACTORY_PID_CONFIGS;
+import static org.apache.sling.commons.log.logback.internal.LogConfigManager.LOGBACK_FILE;
+import static org.apache.sling.commons.log.logback.internal.LogConfigManager.LOG_FILE;
+import static org.apache.sling.commons.log.logback.internal.LogConfigManager.LOG_LEVEL;
+import static org.apache.sling.commons.log.logback.internal.LogConfigManager.LOG_LOGGERS;
+import static org.apache.sling.commons.log.logback.internal.LogConfigManager.LOG_PACKAGING_DATA;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.ops4j.pax.exam.CoreOptions.composite;
+import static org.ops4j.pax.exam.CoreOptions.mavenBundle;
+
+@RunWith(PaxExam.class)
+@ExamReactorStrategy(PerMethod.class)
+public class ITPackagingData extends LogTestBase {
+
+    @Inject
+    private BundleContext bundleContext;
+
+    @Inject
+    private ConfigurationAdmin ca;
+
+    @Override
+    protected Option addExtraOptions() {
+        return composite(
+                configAdmin(),
+                mavenBundle("org.ops4j.pax.tinybundles", "tinybundles").versionAsInProject(),
+                mavenBundle("biz.aQute.bnd", "bndlib").versionAsInProject(),
+                mavenBundle("commons-io", "commons-io").versionAsInProject()
+        );
+    }
+
+    @Test
+    public void defaultWorking() throws Exception{
+        ServiceTracker<WeavingHook, WeavingHook> tracker = createWeavingHookTracker();
+        tracker.open();
+
+        assertNull(tracker.getService());
+        tracker.close();
+    }
+
+    @Test
+    public void packagingEnabled() throws Exception{
+        // Set log level to debug for Root logger
+        Configuration config = ca.getConfiguration(PID, null);
+        Dictionary<String, Object> p = new Hashtable<String, Object>();
+        p.put(LOG_PACKAGING_DATA, Boolean.TRUE);
+        p.put(LOG_LEVEL, "INFO");
+        config.update(p);
+
+        delay();
+
+        ServiceTracker<WeavingHook, WeavingHook> tracker = createWeavingHookTracker();
+        tracker.open();
+
+        assertNotNull(tracker.getService());
+        tracker.close();
+    }
+
+    @Test
+    public void packageDataWorking() throws Exception{
+        // Enable packaging
+        Configuration config = ca.getConfiguration(PID, null);
+        Dictionary<String, Object> p = new Hashtable<String, Object>();
+        p.put(LOG_PACKAGING_DATA, Boolean.TRUE);
+        p.put(LOG_LEVEL, "INFO");
+        config.update(p);
+        delay();
+
+        //Configure a file logger for test class
+        Configuration config2 = ca.createFactoryConfiguration(FACTORY_PID_CONFIGS, null);
+        Dictionary<String, Object> p2 = new Hashtable<String, Object>();
+        p2.put(LOG_LOGGERS, new String[] {
+                PackageDataActivator.LOGGER_NAME
+        });
+        String logFileName = "logs/package-test.log";
+        p2.put(LOG_FILE, logFileName);
+        p2.put(LOG_LEVEL, "INFO");
+        config2.update(p2);
+        delay();
+
+
+        //Ensure that weaving hook comes up
+        ServiceTracker<WeavingHook, WeavingHook> tracker = createWeavingHookTracker();
+        tracker.open();
+        tracker.waitForService(60*1000);
+
+        //Now install the test bundle such that hook picks it up
+        InputStream inp = PackagingDataTestUtil.createTestBundle();
+        Bundle b = bundleContext.installBundle("test", inp);
+        b.start();
+
+        //Now wait for runnable registered by the test bundle
+        ServiceTracker<Runnable, Runnable> runableTracker = createTracker(Runnable.class, PackageDataActivator.LOGGER_NAME);
+        runableTracker.open();
+
+        //Now invoke the method to trigger logger call with exception
+        Runnable r = runableTracker.waitForService(60*1000);
+        r.run();
+
+        //Now read the log file content to assert that stacktrace has version present
+        String slingHome = System.getProperty("sling.home");
+        File logFile = new File(FilenameUtils.concat(slingHome, logFileName));
+        String logFileContent = FileUtils.readFileToString(logFile);
+
+        System.out.println("--------------------");
+        System.out.println(logFileContent);
+        System.out.println("--------------------");
+
+        List<String> lines = FileUtils.readLines(logFile);
+        String testLine = null;
+        for (String l : lines) {
+            if (l.contains("org.apache.sling.commons.log.logback.integration.bundle.TestRunnable.run(")){
+                testLine = l;
+                break;
+            }
+        }
+        assertNotNull(testLine);
+        assertThat(testLine, containsString("["+PackagingDataTestUtil.TEST_BUNDLE_VERSION+"]"));
+
+        //Check that default logback support is still disabled
+        assertFalse(((LoggerContext) LoggerFactory.getILoggerFactory()).isPackagingDataEnabled());
+    }
+
+    private ServiceTracker<WeavingHook, WeavingHook> createWeavingHookTracker() throws InvalidSyntaxException {
+        return createTracker(WeavingHook.class, LogbackManager.PACKAGE_INFO_COLLECTOR_DESC);
+    }
+
+    private <T> ServiceTracker<T,T> createTracker(Class<T> clazz, String desc) throws InvalidSyntaxException {
+        String filter = String.format("(&(%s=%s)(%s=%s))", Constants.OBJECTCLASS, clazz.getName(),
+                Constants.SERVICE_DESCRIPTION, desc);
+        Filter f = FrameworkUtil.createFilter(filter);
+        return new ServiceTracker<>(bundleContext, f, null);
+    }
+
+}

--- a/src/test/java/org/apache/sling/commons/log/logback/integration/ITPackagingData.java
+++ b/src/test/java/org/apache/sling/commons/log/logback/integration/ITPackagingData.java
@@ -51,8 +51,9 @@ import org.osgi.util.tracker.ServiceTracker;
 import org.slf4j.LoggerFactory;
 
 import static org.apache.sling.commons.log.logback.integration.ITConfigAdminSupport.PID;
+import static org.apache.sling.commons.log.logback.integration.PackagingDataTestUtil.TEST_BUNDLE_NAME;
+import static org.apache.sling.commons.log.logback.integration.PackagingDataTestUtil.TEST_BUNDLE_VERSION;
 import static org.apache.sling.commons.log.logback.internal.LogConfigManager.FACTORY_PID_CONFIGS;
-import static org.apache.sling.commons.log.logback.internal.LogConfigManager.LOGBACK_FILE;
 import static org.apache.sling.commons.log.logback.internal.LogConfigManager.LOG_FILE;
 import static org.apache.sling.commons.log.logback.internal.LogConfigManager.LOG_LEVEL;
 import static org.apache.sling.commons.log.logback.internal.LogConfigManager.LOG_LOGGERS;
@@ -171,7 +172,7 @@ public class ITPackagingData extends LogTestBase {
             }
         }
         assertNotNull(testLine);
-        assertThat(testLine, containsString("["+PackagingDataTestUtil.TEST_BUNDLE_VERSION+"]"));
+        assertThat(testLine, containsString("["+ TEST_BUNDLE_NAME+":"+TEST_BUNDLE_VERSION+"]"));
 
         //Check that default logback support is still disabled
         assertFalse(((LoggerContext) LoggerFactory.getILoggerFactory()).isPackagingDataEnabled());

--- a/src/test/java/org/apache/sling/commons/log/logback/integration/PackagingDataTestUtil.java
+++ b/src/test/java/org/apache/sling/commons/log/logback/integration/PackagingDataTestUtil.java
@@ -36,11 +36,12 @@ import static org.ops4j.pax.tinybundles.core.TinyBundles.withBnd;
 public class PackagingDataTestUtil {
 
     public static final String TEST_BUNDLE_VERSION = "0.0.7";
+    public static final String TEST_BUNDLE_NAME = "packagedatatest";
 
     public static InputStream createTestBundle() {
         return bundle()
                 .set(Constants.BUNDLE_ACTIVATOR, PackageDataActivator.class.getName())
-                .set(Constants.BUNDLE_SYMBOLICNAME, "packagedatatest")
+                .set(Constants.BUNDLE_SYMBOLICNAME, TEST_BUNDLE_NAME)
                 .set(Constants.BUNDLE_VERSION, TEST_BUNDLE_VERSION)
                 .add(PackageDataActivator.class, InnerClassStrategy.NONE)
                 .add(TestRunnable.class, InnerClassStrategy.NONE)

--- a/src/test/java/org/apache/sling/commons/log/logback/integration/PackagingDataTestUtil.java
+++ b/src/test/java/org/apache/sling/commons/log/logback/integration/PackagingDataTestUtil.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sling.commons.log.logback.integration;
+
+import java.io.InputStream;
+
+import org.apache.sling.commons.log.logback.integration.bundle.PackageDataActivator;
+import org.apache.sling.commons.log.logback.integration.bundle.TestRunnable;
+import org.ops4j.pax.tinybundles.core.InnerClassStrategy;
+import org.osgi.framework.Constants;
+
+import static org.ops4j.pax.tinybundles.core.TinyBundles.bundle;
+import static org.ops4j.pax.tinybundles.core.TinyBundles.withBnd;
+
+/**
+ * Have to use a separate class due to TinyBundles having issue and recommends put bundle
+ * creation logic in separate class
+ */
+public class PackagingDataTestUtil {
+
+    public static final String TEST_BUNDLE_VERSION = "0.0.7";
+
+    public static InputStream createTestBundle() {
+        return bundle()
+                .set(Constants.BUNDLE_ACTIVATOR, PackageDataActivator.class.getName())
+                .set(Constants.BUNDLE_SYMBOLICNAME, "packagedatatest")
+                .set(Constants.BUNDLE_VERSION, TEST_BUNDLE_VERSION)
+                .add(PackageDataActivator.class, InnerClassStrategy.NONE)
+                .add(TestRunnable.class, InnerClassStrategy.NONE)
+                .build(withBnd());
+    }
+}

--- a/src/test/java/org/apache/sling/commons/log/logback/integration/bundle/PackageDataActivator.java
+++ b/src/test/java/org/apache/sling/commons/log/logback/integration/bundle/PackageDataActivator.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sling.commons.log.logback.integration.bundle;
+
+import java.util.Hashtable;
+
+import org.osgi.framework.BundleActivator;
+import org.osgi.framework.BundleContext;
+import org.osgi.framework.Constants;
+
+public class PackageDataActivator implements BundleActivator {
+    public static final String LOGGER_NAME = "test.PackageDataActivator";
+
+    @Override
+    public void start(BundleContext context) throws Exception {
+        Hashtable props = new Hashtable();
+        props.put(Constants.SERVICE_DESCRIPTION, LOGGER_NAME);
+        context.registerService(Runnable.class.getName(), new TestRunnable(), props);
+    }
+
+    @Override
+    public void stop(BundleContext context) throws Exception {
+
+    }
+
+}

--- a/src/test/java/org/apache/sling/commons/log/logback/integration/bundle/TestRunnable.java
+++ b/src/test/java/org/apache/sling/commons/log/logback/integration/bundle/TestRunnable.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sling.commons.log.logback.integration.bundle;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TestRunnable implements Runnable {
+    private final Logger log = LoggerFactory.getLogger(PackageDataActivator.LOGGER_NAME);
+
+    @Override
+    public void run() {
+        log.warn("==PackageDataActivator==", new Exception());
+    }
+}

--- a/src/test/java/org/apache/sling/commons/log/logback/internal/stacktrace/PackageInfoCollectorTest.java
+++ b/src/test/java/org/apache/sling/commons/log/logback/internal/stacktrace/PackageInfoCollectorTest.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.sling.commons.log.logback.internal.stacktrace;
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class PackageInfoCollectorTest {
+    @Test
+    public void packageName() throws Exception{
+        assertEquals("com.foo", PackageInfoCollector.getPackageName("com.foo.TestClass"));
+        assertEquals("", PackageInfoCollector.getPackageName("packageInDefaultClass"));
+    }
+
+}

--- a/src/test/java/org/apache/sling/commons/log/logback/internal/stacktrace/PackageInfoCollectorTest.java
+++ b/src/test/java/org/apache/sling/commons/log/logback/internal/stacktrace/PackageInfoCollectorTest.java
@@ -20,14 +20,60 @@
 package org.apache.sling.commons.log.logback.internal.stacktrace;
 
 import org.junit.Test;
+import org.osgi.framework.Bundle;
+import org.osgi.framework.Version;
+import org.osgi.framework.hooks.weaving.WovenClass;
+import org.osgi.framework.wiring.BundleWiring;
 
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class PackageInfoCollectorTest {
+    private PackageInfoCollector collector = new PackageInfoCollector();
+
     @Test
     public void packageName() throws Exception{
         assertEquals("com.foo", PackageInfoCollector.getPackageName("com.foo.TestClass"));
         assertEquals("", PackageInfoCollector.getPackageName("packageInDefaultClass"));
     }
 
+    @Test
+    public void getBundleInfo() throws Exception{
+        Bundle bundle = newBundle("foo.bundle", "0.0.7");
+        collector.weave(newWovenClass(bundle, "com.example.Foo"));
+
+        assertEquals("foo.bundle:0.0.7",collector.getBundleInfo("com.example.Foo"));
+        assertEquals("foo.bundle:0.0.7",collector.getBundleInfo("com.example.Bar"));
+        assertNull(collector.getBundleInfo("com.example2.Bar"));
+    }
+
+    /**
+     * For case where same package is present in multiple bundles then no bundle info is provided
+     */
+    @Test
+    public void duplicates() throws Exception{
+        collector.weave(newWovenClass(newBundle("foo.bundle", "0.0.7"), "com.example.Foo"));
+        collector.weave(newWovenClass(newBundle("foo.bundle2", "0.0.8"), "com.example.Bar"));
+
+        assertNull(collector.getBundleInfo("com.example.Bar"));
+    }
+
+    private Bundle newBundle(String name, String version){
+        Bundle b = mock(Bundle.class);
+        when(b.getSymbolicName()).thenReturn(name);
+        when(b.getVersion()).thenReturn(Version.parseVersion(version));
+        return b;
+    }
+
+    private WovenClass newWovenClass(Bundle bundle, String className){
+        WovenClass woven = mock(WovenClass.class);
+        BundleWiring wiring = mock(BundleWiring.class);
+        when(woven.getBundleWiring()).thenReturn(wiring);
+
+        when(wiring.getBundle()).thenReturn(bundle);
+        when(woven.getClassName()).thenReturn(className);
+        return woven;
+    }
 }


### PR DESCRIPTION
Uses WeavingHook to capture class to bundle mapping and uses that to decorate the stacktrace when logback writes it to appender