### PR TITLE
removing logging bug from line 575 of SlingLogPanel.java

### DIFF
--- a/src/main/java/org/apache/sling/commons/log/logback/internal/SlingLogPanel.java
+++ b/src/main/java/org/apache/sling/commons/log/logback/internal/SlingLogPanel.java
@@ -572,7 +572,7 @@ public class SlingLogPanel implements LogPanel {
                 return;
             }
         }
-        pw.printf("No appender with name [%s] found", appenderName);
+        pw.printf("No appender with name [%s] found", XmlUtil.escapeXml(appenderName));
     }
 
     private String getLinkedName(FileAppender<ILoggingEvent> appender) throws UnsupportedEncodingException {


### PR DESCRIPTION
It looks like the edit suggested here:
https://github.com/apache/sling-old-svn-mirror/pull/224/files
Was not migrated with the rest of the repo.  This should remove the logging bug present in SlingLogPanel.java