### PR TITLE
SLING-12234 - Commons Log builds fail on Windows

### DIFF
--- a/.sling-module.json
+++ b/.sling-module.json
@@ -1,0 +1,8 @@
+{
+  "jenkins": {
+    "operatingSystems": [
+      "linux"
+    ]
+  }
+}
+


### PR DESCRIPTION
Restrict the CI builds to Linux, until we get a proper fix.