### PR TITLE
SLING-13067 Bump logback to 1.5.32

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     </scm>
 
     <properties>
-        <logback.version>1.5.26</logback.version>
+        <logback.version>1.5.29</logback.version>
         <!-- Higher versions of pax exam cause class loading errors -->
         <org.ops4j.pax.exam.version>4.13.3</org.ops4j.pax.exam.version>
         <project.build.outputTimestamp>1763081338</project.build.outputTimestamp>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     </scm>
 
     <properties>
-        <logback.version>1.5.31</logback.version>
+        <logback.version>1.5.32</logback.version>
         <!-- Higher versions of pax exam cause class loading errors -->
         <org.ops4j.pax.exam.version>4.13.3</org.ops4j.pax.exam.version>
         <project.build.outputTimestamp>1763081338</project.build.outputTimestamp>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     </scm>
 
     <properties>
-        <logback.version>1.5.29</logback.version>
+        <logback.version>1.5.31</logback.version>
         <!-- Higher versions of pax exam cause class loading errors -->
         <org.ops4j.pax.exam.version>4.13.3</org.ops4j.pax.exam.version>
         <project.build.outputTimestamp>1763081338</project.build.outputTimestamp>


### PR DESCRIPTION
Bump logback to ~~1.5.29~~ 1.5.32

Also some refactoring to compensate for upstream changes that broke some tests.  These compensate for changes made at https://github.com/qos-ch/logback/commit/e7764f47e51921abe9635b32c2fa80e65d29efba and apply a fix that is similar to the changes that were done to ReconfigureOnChangeTask.java‎ in that revision